### PR TITLE
fix: skip doublestar.Match when path has no glob characters

### DIFF
--- a/fs/s3.go
+++ b/fs/s3.go
@@ -66,7 +66,7 @@ func (t *s3FS) Close() error {
 }
 
 func (t *s3FS) ReadDir(pattern string) ([]FileInfo, error) {
-	prefix, _ := doublestar.SplitPattern(pattern)
+	prefix, glob := doublestar.SplitPattern(pattern)
 	if prefix == "." {
 		prefix = ""
 	}
@@ -80,6 +80,7 @@ func (t *s3FS) ReadDir(pattern string) ([]FileInfo, error) {
 		req.MaxKeys = lo.ToPtr(int32(t.maxObjects))
 	}
 
+	hasGlob := glob != ""
 	var output []FileInfo
 	var numObjectsFetched int
 	for {
@@ -89,7 +90,7 @@ func (t *s3FS) ReadDir(pattern string) ([]FileInfo, error) {
 		}
 
 		for _, obj := range resp.Contents {
-			if pattern != "" {
+			if hasGlob {
 				if matched, err := doublestar.Match(pattern, *obj.Key); err != nil {
 					return nil, err
 				} else if !matched {


### PR DESCRIPTION
## Summary
- When `ReadDir` is called with a plain S3 prefix (e.g. `sql/`), `doublestar.SplitPattern` returns an empty glob part
- Previously, `doublestar.Match("sql/", key)` was applied to every listed object, rejecting all nested keys (e.g. `sql/2026-02-19/file.csv.gz`) and returning an empty result set
- This caused canary-checker folder checks with `recursive: true` to silently find 0 files, then fail on a `HeadObject` 404 when trying to `Stat` the prefix

## Fix
Only apply the `doublestar.Match` filter when `SplitPattern` produces a non-empty glob component. When no glob is present, all objects under the prefix are returned (matching the behavior of GCS `ReadDir`).

## Test plan
- [x] Verified with `canary-checker run` against an S3 bucket with ~12k objects across date-partitioned folders
- [ ] Existing tests pass